### PR TITLE
Tile bodies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,8 +18,10 @@ dependencies {
     api(libs.fleks)
     api(libs.gdx)
     api(libs.gdxAi)
+    api(libs.gdxBox2d)
     api(libs.ktxActors)
     api(libs.ktxApp)
+    api(libs.ktxBox2d)
     api(libs.ktxGraphics)
     api(libs.ktxVis)
 }

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/JamGame.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/JamGame.kt
@@ -1,15 +1,17 @@
 package io.github.fourlastor.jamjam
 
 import com.badlogic.gdx.Screen
+import com.badlogic.gdx.physics.box2d.Box2D
 import io.github.fourlastor.jamjam.level.LevelScreen
 import ktx.app.KtxGame
 
 class JamGame : KtxGame<Screen>() {
 
     override fun create() {
+        Box2D.init()
         addScreen(LevelScreen())
         addScreen(MenuScreen(this))
-        setScreen<MenuScreen>()
+        setScreen<LevelScreen>()
     }
 
     fun startGame() {

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LDtkConverter.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LDtkConverter.kt
@@ -2,20 +2,35 @@ package io.github.fourlastor.jamjam.level
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.graphics.g2d.TextureAtlas
+import com.badlogic.gdx.math.Rectangle
 import io.github.fourlastor.ldtk.Definitions
 import io.github.fourlastor.ldtk.LDtkLayerInstance
 import io.github.fourlastor.ldtk.LDtkLevelDefinition
 
-class LDtkConverter(private val scale: Float = 1f) {
-    fun convert(levelDefinition: LDtkLevelDefinition, definitions: Definitions): WorldLevel {
-        return levelDefinition.toLevel(definitions)
-    }
+class LDtkConverter(private val scale: Float) {
+    fun convert(levelDefinition: LDtkLevelDefinition, definitions: Definitions): WorldLevel = WorldLevel(
+        layers = levelDefinition.layerInstances.orEmpty().reversed()
+            .mapIndexedNotNull { i, it -> it.toLayer(i, definitions) },
+        boxes = levelDefinition.layerInstances?.firstOrNull { it.type == "IntGrid" }
+            .toBoxes()
+    )
 
-    private fun LDtkLevelDefinition.toLevel(definitions: Definitions): WorldLevel {
-        return WorldLevel(
-            layers = layerInstances.orEmpty().reversed().mapIndexedNotNull { i, it -> it.toLayer(i, definitions) })
-    }
+    /** Converts an IntGrid layer to definitions used in the physics world. */
+    private fun LDtkLayerInstance?.toBoxes(): List<Rectangle> = this?.run {
+        intGridCSV.orEmpty()
+            .mapIndexedNotNull { index, i ->
+                index.takeIf { i == 1 }?.let {
+                    Rectangle(
+                        (index % cWid).toFloat(),
+                        (index / cWid).toFloat(),
+                        gridSize * scale,
+                        gridSize * scale,
+                    )
+                }
+            }
+    }.orEmpty()
 
+    /** Converts an AutoLayer to a renderable [WorldLevel.Layer]. */
     private fun LDtkLayerInstance.toLayer(position: Int, definitions: Definitions): WorldLevel.Layer? =
         when (type) {
             "AutoLayer" -> {
@@ -42,6 +57,7 @@ class LDtkConverter(private val scale: Float = 1f) {
                             })
                     }
             }
+
             else -> null
         }
 }

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LDtkConverter.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LDtkConverter.kt
@@ -30,6 +30,7 @@ class LDtkConverter(private val scale: Float = 1f) {
                                     .let { tileId -> tileset.customData.find { it.tileId == tileId } }
                                     ?.let { atlas.createSprite(it.data) }
                                     ?.apply {
+                                        setOrigin(0f, 0f)
                                         setScale(scale)
                                         setPosition(tile.px[0] * scale, tile.px[1] * scale)
 

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LevelScreen.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LevelScreen.kt
@@ -13,14 +13,23 @@ import ktx.app.KtxScreen
 class LevelScreen : KtxScreen {
 
     private val mapData = LDtkReader().data(Gdx.files.internal("maps.ldtk").read())
-    private val level = LDtkConverter(1f / 16f).convert(mapData.levelDefinitions[0], mapData.defs)
+    private val levelIndex = 0
+    private val levelDefinition = mapData.levelDefinitions[levelIndex]
+    private val level = LDtkConverter(1f / 16f).convert(levelDefinition, mapData.defs)
+
+    private val camera = OrthographicCamera().apply {
+        setToOrtho(true)
+    }
+    private val viewport = FitViewport(16f, 10f, camera).also {
+        camera.center(it.worldWidth, it.worldHeight)
+    }
 
     private val camera = OrthographicCamera().apply { setToOrtho(true) }
     private val viewport = FitViewport(16f, 10f, camera)
 
     private val world =
         World {
-            inject(camera)
+            inject<Camera>(viewport.camera)
             system<RenderSystem>()
         }
             .apply {
@@ -34,7 +43,7 @@ class LevelScreen : KtxScreen {
     }
 
     override fun resize(width: Int, height: Int) {
-        viewport.update(width, height, true)
+        viewport.update(width, height, false)
     }
 
     override fun render(delta: Float) {

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LevelScreen.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/LevelScreen.kt
@@ -2,13 +2,21 @@ package io.github.fourlastor.jamjam.level
 
 import com.badlogic.gdx.Gdx
 import com.badlogic.gdx.Input
+import com.badlogic.gdx.graphics.Camera
 import com.badlogic.gdx.graphics.OrthographicCamera
 import com.badlogic.gdx.utils.viewport.FitViewport
 import com.github.quillraven.fleks.World
+import io.github.fourlastor.jamjam.level.system.BodiesListener
+import io.github.fourlastor.jamjam.level.system.Box2dComponent
 import io.github.fourlastor.jamjam.level.system.LayerComponent
+import io.github.fourlastor.jamjam.level.system.PhisycsDebugSystem
+import io.github.fourlastor.jamjam.level.system.PhisycsSystem
 import io.github.fourlastor.jamjam.level.system.RenderSystem
 import io.github.fourlastor.ldtk.LDtkReader
 import ktx.app.KtxScreen
+import ktx.box2d.createWorld
+import ktx.box2d.earthGravity
+import ktx.graphics.center
 
 class LevelScreen : KtxScreen {
 
@@ -24,18 +32,23 @@ class LevelScreen : KtxScreen {
         camera.center(it.worldWidth, it.worldHeight)
     }
 
-    private val camera = OrthographicCamera().apply { setToOrtho(true) }
-    private val viewport = FitViewport(16f, 10f, camera)
+    private val box2dWorld = createWorld(gravity = earthGravity)
 
     private val world =
         World {
             inject<Camera>(viewport.camera)
+            inject(box2dWorld)
+            inject(PhisycsSystem.Config(step = 1f / 60f))
             system<RenderSystem>()
+            system<PhisycsSystem>()
+            componentListener<BodiesListener>()
+            system<PhisycsDebugSystem>()
         }
             .apply {
                 level.layers.forEach { gameLayer ->
                     entity { add<LayerComponent> { layer = gameLayer } }
                 }
+                entity { add<Box2dComponent> { boxes = level.boxes } }
             }
 
     override fun show() {
@@ -61,19 +74,6 @@ class LevelScreen : KtxScreen {
         if (Gdx.input.isKeyPressed(Input.Keys.D)) {
             camera.translate(factor, 0f, 0f)
         }
-        if (Gdx.input.isKeyPressed(Input.Keys.W)) {
-            camera.translate(0f, -factor, 0f)
-        }
-        if (Gdx.input.isKeyPressed(Input.Keys.S)) {
-            camera.translate(0f, factor, 0f)
-        }
-
-        val effectiveViewportWidth: Float = camera.viewportWidth * camera.zoom
-        val effectiveViewportHeight: Float = camera.viewportHeight * camera.zoom
-        camera.position.x =
-            camera.position.x.coerceIn(effectiveViewportWidth / 2f, 100 - effectiveViewportWidth / 2f)
-        camera.position.y =
-            camera.position.y.coerceIn(effectiveViewportHeight / 2f, 100 - effectiveViewportHeight / 2f)
     }
 
     override fun dispose() {

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/WorldLevel.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/WorldLevel.kt
@@ -3,11 +3,13 @@ package io.github.fourlastor.jamjam.level
 import com.badlogic.gdx.graphics.g2d.Sprite
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.badlogic.gdx.graphics.g2d.TextureAtlas
+import com.badlogic.gdx.math.Rectangle
 import com.badlogic.gdx.utils.Disposable
-import java.lang.Float.max
-import kotlin.math.min
 
-class WorldLevel(val layers: List<Layer>) : Disposable {
+class WorldLevel(
+    val layers: List<Layer>,
+    val boxes: List<Rectangle>,
+) : Disposable {
 
     override fun dispose() {
         layers.forEach { it.dispose() }
@@ -26,16 +28,8 @@ class WorldLevel(val layers: List<Layer>) : Disposable {
         ) : Layer() {
 
             override fun render(batch: SpriteBatch) {
-                var minx = Float.MAX_VALUE
-                var miny = Float.MAX_VALUE
-                var maxx = Float.MIN_VALUE
-                var maxy = Float.MIN_VALUE
                 tiles.forEach {
                     it.draw(batch)
-                    minx = min(minx, it.x)
-                    miny = min(miny, it.y)
-                    maxx = max(maxx, it.x)
-                    maxy = max(maxy, it.y)
                 }
             }
 

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsDebugSystem.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsDebugSystem.kt
@@ -1,0 +1,19 @@
+package io.github.fourlastor.jamjam.level.system
+
+import com.badlogic.gdx.graphics.Camera
+import com.badlogic.gdx.physics.box2d.Box2DDebugRenderer
+import com.badlogic.gdx.physics.box2d.World
+import com.github.quillraven.fleks.IntervalSystem
+
+class PhisycsDebugSystem(
+    private val camera: Camera,
+    private val box2dWorld: World,
+) : IntervalSystem() {
+
+    private val debugRender by lazy { Box2DDebugRenderer() }
+
+    override fun onTick() {
+        debugRender.render(box2dWorld, camera.combined)
+    }
+
+}

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsDebugSystem.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsDebugSystem.kt
@@ -10,10 +10,14 @@ class PhisycsDebugSystem(
     private val box2dWorld: World,
 ) : IntervalSystem() {
 
-    private val debugRender by lazy { Box2DDebugRenderer() }
+    private val debugRenderer = Box2DDebugRenderer()
 
     override fun onTick() {
-        debugRender.render(box2dWorld, camera.combined)
+        debugRenderer.render(box2dWorld, camera.combined)
+    }
+
+    override fun onDispose() {
+        debugRenderer.dispose()
     }
 
 }

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsSystem.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/PhysicsSystem.kt
@@ -1,0 +1,53 @@
+package io.github.fourlastor.jamjam.level.system
+
+import com.badlogic.gdx.math.Rectangle
+import com.badlogic.gdx.math.Vector2
+import com.badlogic.gdx.physics.box2d.Body
+import com.badlogic.gdx.physics.box2d.World
+import com.github.quillraven.fleks.ComponentListener
+import com.github.quillraven.fleks.Entity
+import com.github.quillraven.fleks.Fixed
+import com.github.quillraven.fleks.IntervalSystem
+import ktx.box2d.body
+import ktx.box2d.box
+
+class PhisycsSystem(
+    private val config: Config,
+    private val box2dWorld: World,
+) : IntervalSystem(interval = Fixed(config.step)) {
+
+    override fun onTick() {
+        box2dWorld.step(config.step, 6, 2)
+    }
+
+    data class Config(
+        val step: Float,
+    )
+}
+
+class BodiesListener(
+    private val box2dWorld: World,
+) : ComponentListener<Box2dComponent> {
+
+    override fun onComponentAdded(entity: Entity, component: Box2dComponent) {
+        component.body = box2dWorld.body {
+            component.boxes.forEach { box ->
+                box(
+                    width = box.width,
+                    height = box.height,
+                    position = Vector2(
+                        box.x + box.width / 2,
+                        box.y + box.height / 2
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onComponentRemoved(entity: Entity, component: Box2dComponent) = Unit
+}
+
+class Box2dComponent {
+    lateinit var boxes: List<Rectangle>
+    lateinit var body: Body
+}

--- a/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/RenderSystem.kt
+++ b/core/src/main/kotlin/io/github/fourlastor/jamjam/level/system/RenderSystem.kt
@@ -1,6 +1,6 @@
 package io.github.fourlastor.jamjam.level.system
 
-import com.badlogic.gdx.graphics.OrthographicCamera
+import com.badlogic.gdx.graphics.Camera
 import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.github.quillraven.fleks.AllOf
 import com.github.quillraven.fleks.ComponentMapper
@@ -14,7 +14,7 @@ import ktx.graphics.use
 @AllOf([LayerComponent::class])
 class RenderSystem(
     private val layers: ComponentMapper<LayerComponent>,
-    private val camera: OrthographicCamera,
+    private val camera: Camera,
 ) :
     IteratingSystem(
         compareEntity { entity, entity2 ->

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -24,6 +24,7 @@ application {
 dependencies {
     api(project(":core"))
     api("com.badlogicgames.gdx:gdx-platform:${libs.versions.gdx.get()}:natives-desktop")
+    api("com.badlogicgames.gdx:gdx-box2d-platform:${libs.versions.gdx.get()}:natives-desktop")
     api(libs.gdxBackendLwjgl3)
     api(libs.controllersDesktop)
 }

--- a/desktop/src/main/kotlin/io/github/fourlastor/jamjam/DesktopLauncher.kt
+++ b/desktop/src/main/kotlin/io/github/fourlastor/jamjam/DesktopLauncher.kt
@@ -5,7 +5,7 @@ import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration
 
 fun main() {
     val config = Lwjgl3ApplicationConfiguration().apply {
-        setWindowedMode(1920, 1200)
+        setWindowedMode(960, 600)
         setForegroundFPS(60)
     }
     Lwjgl3Application(JamGame(), config)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,9 +13,11 @@ fleks = { module = "io.github.quillraven.fleks:Fleks", version.ref = "fleks" }
 gdx = { module = "com.badlogicgames.gdx:gdx", version.ref = "gdx" }
 gdxAi = { module = "com.badlogicgames.gdx:gdx-ai", version.ref = "gdxAi" }
 gdxBackendLwjgl3 = { module = "com.badlogicgames.gdx:gdx-backend-lwjgl3", version.ref = "gdx" }
+gdxBox2d = { module = "com.badlogicgames.gdx:gdx-box2d", version.ref = "gdx" }
 gltf = { module = "com.github.mgsx-dev.gdx-gltf:gltf", version.ref = "gltf" }
 ktxActors = { module = "io.github.libktx:ktx-actors", version.ref = "ktx" }
 ktxApp = { module = "io.github.libktx:ktx-app", version.ref = "ktx" }
+ktxBox2d = { module = "io.github.libktx:ktx-box2d", version.ref = "ktx" }
 ktxGraphics = { module = "io.github.libktx:ktx-graphics", version.ref = "ktx" }
 ktxVis = { module = "io.github.libktx:ktx-vis", version.ref = "ktx" }
 serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serializationJson" }


### PR DESCRIPTION
1. LevelScreen is the default screen
2. Added Box2d
3. Fixed a small bug in the tile renderer: changed the origin to 0,0 before scaling, so that the tiles aren't offset
4. Removed auto centering the camera on resize
5. Added bodies for `IntGrid` layers
6. Injected cameras are now typed as `Camera`
7. Reduced the default window size